### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ terraform.tfvars
 terraform.tfstate.*
 terraform.tfstate*
 *.pem
-ark.tfvars
 ark
-ark.pub
+*.pub
+*.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ terraform.tfvars
 terraform.tfstate.*
 terraform.tfstate*
 *.pem
+ark.tfvars
+ark
+ark.pub

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ terraform.tfvars
 .terraform*
 terraform.tfstate.*
 terraform.tfstate*
+*.pem

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ secret_key = "ASDFASDFASDFA"
 key_name = "ark"
 ```
 4. Test the template to ensure it's working:
-`terraform plan -var-file=./terraform.tfvars -input=false`
+`terraform plan -var-file=./ark.tfvars -input=false`
 
 5. Execute template:
 `terraform apply -var-file=./ark.tfvars -input=false`
+
+6. ssh into
+
+`ssh -i "arkkey.pem" ubuntu@ec2-54-71-238-67.us-west-2.compute.amazonaws.com`
+
+7. follow [this link](https://github.com/arkmanager/ark-server-tools) for instructions on installing/managing ark on the server
+

--- a/ark-server.tf
+++ b/ark-server.tf
@@ -4,13 +4,13 @@ provider "aws" {
     secret_key = var.secret_key
 }
 
-data "aws_ami" "ubuntu-18_04" {
+data "aws_ami" "ubuntu-20_04" {
     most_recent = true
     owners = ["099720109477"] # Canonical
 
     filter {
         name   = "name"
-        values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+        values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-20.04-amd64-server-*"]
     }
 }
 
@@ -74,7 +74,7 @@ resource "aws_security_group" "ark_ports" {
 }
 
 resource "aws_instance" "ark-server" {
-    ami           = data.aws_ami.ubuntu-18_04.id
+    ami           = data.aws_ami.ubuntu-20_04.id
     instance_type = "t2.large"
     key_name      = var.key_name
     security_groups = [aws_security_group.ark_ports.name]
@@ -82,7 +82,7 @@ resource "aws_instance" "ark-server" {
 
     ebs_block_device {
       device_name = "/dev/sdb"
-      volume_type = "gp2"
+      volume_type = "gp3"
       volume_size = "50"
       delete_on_termination = true
     }
@@ -93,5 +93,5 @@ resource "aws_instance" "ark-server" {
 }
 
 output "image_id" {
-    value = data.aws_ami.ubuntu-18_04.id
+    value = data.aws_ami.ubuntu-20_04.id
 }

--- a/ark-server.tf
+++ b/ark-server.tf
@@ -10,7 +10,11 @@ data "aws_ami" "ubuntu-20_04" {
 
     filter {
         name   = "name"
-        values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-20.04-amd64-server-*"]
+        values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    }
+    filter {
+        name = "virtualization-type"
+        values = ["hvm"]
     }
 }
 
@@ -77,7 +81,7 @@ resource "aws_instance" "ark-server" {
     ami           = data.aws_ami.ubuntu-20_04.id
     instance_type = "t2.large"
     key_name      = var.key_name
-    security_groups = [aws_security_group.ark_ports.name]
+    vpc_security_group_ids = [aws_security_group.ark_ports.id]
     associate_public_ip_address = true
 
     ebs_block_device {
@@ -88,7 +92,8 @@ resource "aws_instance" "ark-server" {
     }
 
     tags = {
-      Appliation = "ark"
+      Appliation = "ark",
+      OS = "UBUNTU"
     }
 }
 


### PR DESCRIPTION
I have been using this branch for sometime, probably worth merging to the main repo for anyone using this server. this
- updates the base ami to a more recent LTS for ubuntu, 20_04
- moves storage to gpt3 for newer and [cheaper](https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/) storage
- fixes and adds more instruction to the readme